### PR TITLE
fix: Activities.SIZE 0x56A -> 0x56C to preserve QuestStateList

### DIFF
--- a/SaveEditor/Structs/Activities.cs
+++ b/SaveEditor/Structs/Activities.cs
@@ -10,7 +10,7 @@ namespace SaveEditor.Structs
     [StructLayout(LayoutKind.Sequential, Pack = 1, Size = SIZE)]
     public struct Activities
     {
-        public const int SIZE = 0x56A;
+        public const int SIZE = 0x56C;
 
         public int field_0, field_4, field_8;
 


### PR DESCRIPTION
## Bug

`Activities.SIZE` is `0x56A` but should be `0x56C`. The `field_3F2[2]` was added between `field_3CA` and `QuestStateList`, but the struct size constant was not updated.

## Impact

Every save in FETH_SaveEditor corrupts the last 2 bytes of `QuestStateList` (which controls paralogue availability). This causes DLC paralogues (Black Market Scheme, A Cursed Relic) to become unavailable after any save operation, even when editing unrelated characters.

## Root Cause

`Marshal.StructureToPtr` writes exactly `SIZE` bytes. With `SIZE=0x56A`, the 2 bytes added by `field_3F2[2]` push the last 2 bytes of `QuestStateList` beyond the marshaled region, replacing them with uninitialized/padding bytes.

## Fix

One-line change: `SIZE = 0x56A` → `SIZE = 0x56C`.

## Verification

- `Activities` is at offset `0x24A1D` within SaveData (0x25B20)
- `0x24A1D + 0x56C = 0x24F89` ≤ `0x25B20` ✓
- No other struct size changes needed